### PR TITLE
fix: update copyright holder in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Takasaki
+Copyright (c) 2025 AIMOverse
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request includes a change to the `LICENSE` file. The change updates the copyright holder.

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3): Updated the copyright holder from "Takasaki" to "AIMOverse".