### PR TITLE
docs: update link to contributing guidelines in README

### DIFF
--- a/amico/README.md
+++ b/amico/README.md
@@ -70,6 +70,6 @@ AMICO is released under the [MIT License](https://raw.githubusercontent.com/AIMO
 ## Contributing
 
 Contributions are welcome! Please read
-our [contributing guidelines](https://raw.githubusercontent.com/AIMOverse/amico/main/CONTRIBUTING.md) before submitting
+our [contributing guidelines](https://github.com/AIMOverse/amico/blob/main/CONTRIBUTING.md) before submitting
 a pull request.
 


### PR DESCRIPTION
This pull request includes a change to the `amico/README.md` file to update the URL for the contributing guidelines.

* [`amico/README.md`](diffhunk://#diff-187268c37c8b18fc4e9c5c614e93a34cec7beb1ba70fb75ff4796cb4d2d8fb5aL73-R73): Updated the URL for the contributing guidelines to point to the correct GitHub location.