### PR TITLE
feat: refactor action execution to return Result with ActionError for Error Handling

### DIFF
--- a/amico-core/src/controller/agent.rs
+++ b/amico-core/src/controller/agent.rs
@@ -99,7 +99,9 @@ impl Agent {
                     // The events pool is unlocked
                 }
                 // The action is executed
-                action.execute();
+                if let Err(e) = action.execute() {
+                    error!("{}", e);
+                }
             }
         });
 

--- a/amico-core/src/errors/action_errors.rs
+++ b/amico-core/src/errors/action_errors.rs
@@ -1,0 +1,9 @@
+use std::fmt::Debug;
+
+/// Errors that can occur during executing actions.
+#[derive(thiserror::Error, Debug)]
+pub enum ActionError {
+    /// Error when executing actions
+    #[error("Executing Action Error: {0}")]
+    ExecutingActionError(String),
+}

--- a/amico-core/src/errors/mod.rs
+++ b/amico-core/src/errors/mod.rs
@@ -1,3 +1,6 @@
+mod action_errors;
 mod event_pool_errors;
 
 pub use event_pool_errors::*;
+
+pub use action_errors::*;

--- a/amico-core/src/traits/action.rs
+++ b/amico-core/src/traits/action.rs
@@ -1,7 +1,7 @@
-use std::any::Any;
+use crate::errors::ActionError;
 
 /// Trait representing an action in the system.
 pub trait Action {
     /// Executes the action and returns a response as a boxed `Any` type.
-    fn execute(&self) -> Box<dyn Any>;
+    fn execute(&self) -> Result<(), ActionError>;
 }

--- a/amico/src/actions/print_action.rs
+++ b/amico/src/actions/print_action.rs
@@ -1,5 +1,5 @@
+use amico_core::errors::ActionError;
 use amico_core::traits::Action;
-use std::any::Any;
 use std::thread;
 
 pub struct PrintAction {
@@ -13,10 +13,12 @@ impl PrintAction {
 }
 
 impl Action for PrintAction {
-    fn execute(&self) -> Box<dyn Any> {
+    fn execute(&self) -> Result<(), ActionError> {
         println!("{}", self.message);
         // Simulate some acting time
         thread::sleep(std::time::Duration::from_millis(100));
-        Box::new(self.message.clone())
+        Err(ActionError::ExecutingActionError(
+            "Print action failed".to_string(),
+        ))
     }
 }


### PR DESCRIPTION
This pull request introduces error handling for action execution in the `amico-core` project. The changes include modifying the `Action` trait to return a `Result` type, adding a new `ActionError` enum, and updating relevant implementations to handle errors appropriately.

Error handling improvements:

* [`amico-core/src/controller/agent.rs`](diffhunk://#diff-e7eb821793038182b906d0d80e5dff9cdb4e675ab7105493a4608c2556422d0bL102-R104): Wrapped the `action.execute()` call in a `Result` and logged any errors encountered during execution.
* [`amico-core/src/errors/action_errors.rs`](diffhunk://#diff-3a55c2d98e82b8c38a6a6e9e176d63f6f2111f480a7f92d1c32d7ee64db64281R1-R9): Added a new `ActionError` enum to represent errors that can occur during action execution.
* [`amico-core/src/errors/mod.rs`](diffhunk://#diff-ce7fcd3a68dd2bfe08d99c32e981633fa97acd5a1b407030eac3d975f5fecbfeR1-R6): Included the new `action_errors` module in the errors module.
* [`amico-core/src/traits/action.rs`](diffhunk://#diff-6c5124eb15f590a27ef6ae78488396faac614dcee960d8ff892fce6f980acebeL1-R6): Updated the `Action` trait's `execute` method to return a `Result<(), ActionError>` instead of a boxed `Any` type.

Implementation updates:

* [`amico/src/actions/print_action.rs`](diffhunk://#diff-1d6744dd43b1ec78bf30da67dc528a37aa8a220ad778745746eee7258c4c6734R1-L2): Modified the `PrintAction` implementation to return a `Result` and simulate an error scenario. [[1]](diffhunk://#diff-1d6744dd43b1ec78bf30da67dc528a37aa8a220ad778745746eee7258c4c6734R1-L2) [[2]](diffhunk://#diff-1d6744dd43b1ec78bf30da67dc528a37aa8a220ad778745746eee7258c4c6734L16-R22)